### PR TITLE
update kong authorization_header handling in src/handler.lua

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -73,7 +73,13 @@ local function retrieve_token(conf)
         end
     end
 
-    local authorization_header = kong.request.get_header("authorization")
+    local authorization_header = nil
+    if conf.access_token_header == nil then
+        authorization_header = kong.request.get_header("authorization")
+    else
+        authorization_header = kong.request.get_header(conf.access_token_header)
+    end
+    
     if authorization_header then
         local iterator, iter_err = re_gmatch(authorization_header, "\\s*[Bb]earer\\s+(.+)")
         if not iterator then


### PR DESCRIPTION
Hi @hanfi , 

we get the following error without that adjustment: 
```
2023/01/30 12:38:05 [error] 1127#0: *5538 [kong] init.lua:333 [jwt-keycloak] ...ocal/share/lua/5.1/kong/plugins/jwt-keycloak/handler.lua:327: attempt to index field 'super' (a nil value)
```

My changes based on the following stackoverflow entry: https://stackoverflow.com/a/65315887

Please have a look on these PR. 
